### PR TITLE
Enum values are now forced into lowercase

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -7,7 +7,7 @@ import {PanelModel, PanelModelBase, QuestionRowModel} from "./panel";
 
 export class PageModel extends PanelModelBase implements IPage {
     private numValue: number = -1;
-    public navigationButtonsVisibility: string = "inherit";
+    private navigationButtonsVisibilityValue: string = "inherit";
     constructor(public name: string = "") {
         super(name);
     }
@@ -17,6 +17,10 @@ export class PageModel extends PanelModelBase implements IPage {
         if (this.numValue == value) return;
         this.numValue = value;
         this.onNumChanged(value);
+    }
+    public get navigationButtonsVisibility(): string { return this.navigationButtonsVisibilityValue; }
+    public set navigationButtonsVisibility(newValue: string) {
+      this.navigationButtonsVisibilityValue = newValue.toLowerCase();
     }
     protected getRendredTitle(str: string): string {
         str = super.getRendredTitle(str);
@@ -54,5 +58,5 @@ export class PageModel extends PanelModelBase implements IPage {
 
 }
 
-JsonObject.metaData.addClass("page", [{ name: "navigationButtonsVisibility", default: "inherit", choices: ["iherit", "show", "hide"] }], 
+JsonObject.metaData.addClass("page", [{ name: "navigationButtonsVisibility", default: "inherit", choices: ["inherit", "show", "hide"] }],
     function () { return new PageModel(); }, "panel");

--- a/src/question_baseselect.ts
+++ b/src/question_baseselect.ts
@@ -63,7 +63,7 @@ export class QuestionSelectBase extends Question {
         }
     }
     protected setNewValue(newValue: any) {
-        if (newValue) this.cachedValueForUrlRequestion = newValue;        
+        if (newValue) this.cachedValueForUrlRequestion = newValue;
         super.setNewValue(newValue);
     }
     protected valueFromData(val: any): any {
@@ -106,20 +106,21 @@ export class QuestionSelectBase extends Question {
     }
     get choicesOrder(): string { return this.choicesOrderValue; }
     set choicesOrder(newValue: string) {
+        newValue = newValue.toLowerCase();
         if (newValue == this.choicesOrderValue) return;
         this.choicesOrderValue = newValue;
         this.onVisibleChoicesChanged();
     }
     public get otherText(): string { return this.locOtherText.text; }
-    public set otherText(value: string) { 
-        this.locOtherText.text = value; 
+    public set otherText(value: string) {
+        this.locOtherText.text = value;
         this.onVisibleChoicesChanged();
     }
     public get otherErrorText(): string { return this.locOtherErrorText.text; }
     public set otherErrorText(value: string) { this.locOtherErrorText.text = value;  }
-    public get locOtherText(): LocalizableString { return this.locOtherTextValue; } 
-    public get locOtherErrorText(): LocalizableString { return this.locOtherErrorTextValue; } 
-    
+    public get locOtherText(): LocalizableString { return this.locOtherTextValue; }
+    public get locOtherErrorText(): LocalizableString { return this.locOtherErrorTextValue; }
+
     get visibleChoices(): Array<ItemValue> {
         if (!this.hasOther && this.choicesOrder == "none") return this.activeChoices;
         if(!this.visibleChoicesCache) {

--- a/src/question_matrixdropdownbase.ts
+++ b/src/question_matrixdropdownbase.ts
@@ -23,7 +23,7 @@ export interface IMatrixDropdownData {
 }
 
 export interface IMatrixColumnOwner extends ILocalizableOwner {
-    getRequiredText(): string;    
+    getRequiredText(): string;
 }
 
 export class MatrixDropdownColumn extends Base implements ILocalizableOwner {
@@ -35,9 +35,9 @@ export class MatrixDropdownColumn extends Base implements ILocalizableOwner {
     public isRequired: boolean = false;
     public hasOther: boolean = false;
     public minWidth: string = "";
-    public cellType: string = "default";
-    public inputType: string = "text";
-    public choicesOrder: string = "none";
+    private cellTypeValue: string = "default";
+    private inputTypeValue: string = "text";
+    private choicesOrderValue: string = "none";
     public choicesByUrl: ChoicesRestfull;
     public colOwner: IMatrixColumnOwner = null;
     public validators: Array<SurveyValidator> = new Array<SurveyValidator>();
@@ -54,7 +54,19 @@ export class MatrixDropdownColumn extends Base implements ILocalizableOwner {
         if(title) this.title = title;
     }
     public getType() { return "matrixdropdowncolumn" }
-    
+
+    public get choicesOrder(): string { return this.choicesOrderValue; }
+    public set choicesOrder(newValue: string) {
+      this.choicesOrderValue = newValue.toLowerCase();
+    }
+    public get inputType(): string { return this.inputTypeValue; }
+    public set inputType(newValue: string) {
+      this.inputTypeValue = newValue.toLowerCase();
+    }
+    public get cellType(): string { return this.cellTypeValue; }
+    public set cellType(newValue: string) {
+        this.cellTypeValue = newValue.toLowerCase();
+    }
     public get title(): string { return this.locTitle.text ? this.locTitle.text : this.name; }
     public set title(value: string) { this.locTitle.text = value; }
     public get fullTitle(): string { return this.getFullTitle(this.locTitle.textOrHtml); }
@@ -240,6 +252,7 @@ export class QuestionMatrixDropdownModelBase extends Question implements IMatrix
     }
     public get cellType(): string { return this.cellTypeValue; }
     public set cellType(newValue: string) {
+        newValue = newValue.toLowerCase();
         if (this.cellType == newValue) return;
         this.cellTypeValue = newValue;
         this.fireCallback(this.updateCellsCallback);
@@ -456,7 +469,7 @@ JsonObject.metaData.addClass("matrixdropdowncolumn", ["name", { name: "title", s
         { name: "choicesByUrl:restfull", className: "ChoicesRestfull", onGetValue: function (obj: any) { return obj.choicesByUrl.isEmpty ? null : obj.choicesByUrl; }, onSetValue: function (obj: any, value: any) { obj.choicesByUrl.setData(value); } },
         { name: "inputType", default: "text", choices: ["color", "date", "datetime", "datetime-local", "email", "month", "number", "password", "range", "tel", "text", "time", "url", "week"] },
         { name: "validators:validators", baseClassName: "surveyvalidator", classNamePart: "validator" }],
-        
+
     function () { return new MatrixDropdownColumn(""); });
 
 JsonObject.metaData.addClass("matrixdropdownbase", [{ name: "columns:matrixdropdowncolumns", className: "matrixdropdowncolumn"},

--- a/src/question_multipletext.ts
+++ b/src/question_multipletext.ts
@@ -20,7 +20,7 @@ export class MultipleTextItemModel extends Base implements IValidatorOwner, ILoc
     private locTitleValue: LocalizableString;
     private locPlaceHolderValue: LocalizableString;
     public isRequired: boolean = false;
-    public inputType: string = "text";
+    private inputTypeValue: string = "text";
     validators: Array<SurveyValidator> = new Array<SurveyValidator>();
 
     constructor(public name: any = null, title: string = null) {
@@ -38,6 +38,10 @@ export class MultipleTextItemModel extends Base implements IValidatorOwner, ILoc
         this.data = data;
     }
 
+    public get inputType(): string { return this.inputTypeValue; }
+    public set inputType(newValue: string) {
+      this.inputTypeValue = newValue.toLowerCase();
+    }
     public get title() { return this.locTitle.text ? this.locTitle.text : this.name; }
     public set title(value: string) { this.locTitle.text = value; }
     public get locTitle() { return this.locTitleValue; }
@@ -213,7 +217,7 @@ export class QuestionMultipleTextModel extends Question implements IMultipleText
     }
 }
 
-JsonObject.metaData.addClass("multipletextitem", ["name", "isRequired:boolean", { name: "placeHolder", serializationProperty: "locPlaceHolder"}, 
+JsonObject.metaData.addClass("multipletextitem", ["name", "isRequired:boolean", { name: "placeHolder", serializationProperty: "locPlaceHolder"},
     { name: "inputType", default: "text", choices: ["color", "date", "datetime", "datetime-local", "email", "month", "number", "password", "range", "tel", "text", "time", "url", "week"] },
     { name: "title", serializationProperty: "locTitle" }, { name: "validators:validators", baseClassName: "surveyvalidator", classNamePart: "validator" }],
     function () { return new MultipleTextItemModel(""); });

--- a/src/question_text.ts
+++ b/src/question_text.ts
@@ -5,7 +5,7 @@ import {LocalizableString} from "./localizablestring";
 
 export class QuestionTextModel extends Question {
     public size: number = 25;
-    public inputType: string = "text";
+    private inputTypeValue: string = "text";
     private locPlaceHolderValue: LocalizableString;
     constructor(public name: string) {
         super(name);
@@ -13,6 +13,10 @@ export class QuestionTextModel extends Question {
     }
     public getType(): string {
         return "text";
+    }
+    get inputType(): string { return this.inputTypeValue; }
+    set inputType(type: string) {
+      this.inputTypeValue = type.toLowerCase();
     }
     isEmpty(): boolean {  return super.isEmpty() || this.value === ""; }
     supportGoNextPageAutomatic() { return true; }

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -27,7 +27,7 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
     public showCompletedPage: boolean = true;
     public requiredText: string = "*";
     public questionStartIndex: string = "";
-    public showProgressBar: string = "off";
+    private showProgressBarValue: string = "off";
     public storeOthersAsComment: boolean = true;
     public goNextPageAutomatic: boolean = false;
     public pages: Array<PageModel> = new Array<PageModel>();
@@ -92,7 +92,7 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
         this.locPageNextTextValue = new LocalizableString(this);
         this.locCompleteTextValue = new LocalizableString(this);
         this.locQuestionTitleTemplateValue = new LocalizableString(this, true);
-        
+
         this.textPreProcessor = new TextPreProcessor();
         this.textPreProcessor.onHasValue = function (name: string) { return self.hasProcessedTextValue(name); };
         this.textPreProcessor.onProcess = function (name: string) { return self.getProcessedTextValue(name); };
@@ -125,10 +125,10 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
     }
     //ILocalizableOwner
     public getLocale() { return this.locale; }
-    public getMarkdownHtml(text: string)  { 
+    public getMarkdownHtml(text: string)  {
         var options = {text: text, html: null}
         this.onTextMarkdown.fire(this, options);
-        return options.html; 
+        return options.html;
     }
     public getLocString(str: string) { return surveyLocalization.getString(str); }
 
@@ -161,18 +161,26 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
     }
     public get showQuestionNumbers(): string { return this.showQuestionNumbersValue; };
     public set showQuestionNumbers(value: string) {
+        value = value.toLowerCase();
+        value = (value === "onpage") ? "onPage" : value;
         if (value === this.showQuestionNumbers) return;
         this.showQuestionNumbersValue = value;
         this.updateVisibleIndexes();
     };
+    public get showProgressBar(): string { return this.showProgressBarValue}
+    public set showProgressBar(newValue: string) {
+      this.showProgressBarValue = newValue.toLowerCase();
+    }
     public get processedTitle() { return this.processText(this.locTitle.textOrHtml); }
     public get questionTitleLocation(): string { return this.questionTitleLocationValue; };
     public set questionTitleLocation(value: string) {
+        value = value.toLowerCase();
         if (value === this.questionTitleLocationValue) return;
         this.questionTitleLocationValue = value;
     };
     public get mode(): string { return this.modeValue; }
     public set mode(value: string) {
+        value = value.toLowerCase();
         if (value == this.mode) return;
         if (value != "edit" && value != "display") return;
         this.modeValue = value;
@@ -352,7 +360,7 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
         this.doComplete();
         return true;
     }
-    public get isFirstPage(): boolean { 
+    public get isFirstPage(): boolean {
         if (this.currentPage == null) return true;
         return this.visiblePages.indexOf(this.currentPage) == 0;
     }
@@ -894,12 +902,12 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
 //Make localizable: completedHtml, pagePrevText, pageNextText, completeText
 
 JsonObject.metaData.addClass("survey", [{ name: "locale", choices: () => { return surveyLocalization.getLocales() } },
-    {name: "title", serializationProperty: "locTitle"}, { name: "focusFirstQuestionAutomatic:boolean", default: true}, 
+    {name: "title", serializationProperty: "locTitle"}, { name: "focusFirstQuestionAutomatic:boolean", default: true},
     {name: "completedHtml:html", serializationProperty: "locCompletedHtml"}, { name: "pages", className: "page", visible: false },
     { name: "questions", baseClassName: "question", visible: false, onGetValue: function (obj) { return null; }, onSetValue: function (obj, value, jsonConverter) { var page = obj.addNewPage(""); jsonConverter.toObject({ questions: value }, page); } },
     { name: "triggers:triggers", baseClassName: "surveytrigger", classNamePart: "trigger" },
     "surveyId", "surveyPostId", "cookieName", "sendResultOnPageNext:boolean",
-    { name: "showNavigationButtons:boolean", default: true }, { name: "showTitle:boolean", default: true }, 
+    { name: "showNavigationButtons:boolean", default: true }, { name: "showTitle:boolean", default: true },
     { name: "showPageTitles:boolean", default: true }, { name: "showCompletedPage:boolean", default: true },
     "showPageNumbers:boolean", { name: "showQuestionNumbers", default: "on", choices: ["on", "onPage", "off"] },
     { name: "questionTitleLocation", default: "top", choices: ["top", "bottom"] },

--- a/tests/entries/test.ts
+++ b/tests/entries/test.ts
@@ -11,6 +11,7 @@ export * from '../surveytests';
 export * from '../surveytriggertests';
 export * from '../surveyvalidatortests';
 export * from '../textPreprocessorTests';
+export * from '../lowercasetests'
 
 // localization
 import '../../src/localization/russian';

--- a/tests/lowercasetests.ts
+++ b/tests/lowercasetests.ts
@@ -1,0 +1,86 @@
+import {SurveyModel} from "../src/survey";
+import {PageModel} from "../src/page";
+import {QuestionTextModel} from "../src/question_text";
+import {QuestionMultipleTextModel, MultipleTextItemModel} from "../src/question_multipletext";
+import {QuestionMatrixDropdownModelBase, MatrixDropdownColumn} from "../src/question_matrixdropdownbase";
+import {QuestionSelectBase} from "../src/question_baseselect";
+
+export default QUnit.module("Survey");
+
+QUnit.test("inputType value is always lower-case", function (assert) {
+    var question = new QuestionTextModel("text");
+    question.inputType = "TEXT";
+    assert.strictEqual(question.inputType, "text");
+});
+
+QUnit.test("choicesOrder value is always lower-case", function (assert) {
+    var question = new QuestionSelectBase("base");
+    question.choicesOrder = "RANDOM";
+    assert.strictEqual(question.choicesOrder, "random");
+});
+
+QUnit.test("navigationButtonsVisibility value is always lower-case", function (assert) {
+    var question = new PageModel("base");
+    question.navigationButtonsVisibility = "HIDE";
+    assert.strictEqual(question.navigationButtonsVisibility, "hide");
+});
+
+QUnit.test("MatrixDropdownColumn inputType value is always lower-case", function (assert) {
+    var question = new MatrixDropdownColumn("text");
+    question.inputType = "TEXT";
+    assert.strictEqual(question.inputType, "text");
+});
+
+QUnit.test("MatrixDropdownColumn cellType value is always lower-case", function (assert) {
+    var question = new MatrixDropdownColumn("base");
+    question.cellType = "CHECKBOX";
+    assert.strictEqual(question.cellType, "checkbox");
+});
+
+QUnit.test("MatrixDropdownColumn choicesOrder value is always lower-case", function (assert) {
+    var question = new MatrixDropdownColumn("base");
+    question.choicesOrder = "RANDOM";
+    assert.strictEqual(question.choicesOrder, "random");
+});
+
+QUnit.test("QuestionMatrixDropdownModelBase cellType value is always lower-case", function (assert) {
+    var question = new QuestionMatrixDropdownModelBase("base");
+    question.cellType = "RADIOGROUP";
+    assert.strictEqual(question.cellType, "radiogroup");
+});
+
+QUnit.test("MultipleTextItemModel inputType value is always lower-case", function (assert) {
+    var question = new MultipleTextItemModel("text");
+    question.inputType = "COLOR";
+    assert.strictEqual(question.inputType, "color");
+});
+
+QUnit.test("SurveyModel showQuestionNumbers value is always lower-case", function (assert) {
+    var question = new SurveyModel("text");
+    question.showQuestionNumbers = "OFF";
+    assert.strictEqual(question.showQuestionNumbers, "off");
+});
+
+QUnit.test("SurveyModel showQuestionNumbers value handles onPage special case", function (assert) {
+    var question = new SurveyModel("text");
+    question.showQuestionNumbers = "ONPAGE";
+    assert.strictEqual(question.showQuestionNumbers, "onPage");
+});
+
+QUnit.test("SurveyModel questionTitleLocation value is always lower-case", function (assert) {
+    var question = new SurveyModel("text");
+    question.questionTitleLocation = "BOTTOM";
+    assert.strictEqual(question.questionTitleLocation, "bottom");
+});
+
+QUnit.test("SurveyModel showProgressBar value is always lower-case", function (assert) {
+    var question = new SurveyModel("text");
+    question.showProgressBar = "TOP";
+    assert.strictEqual(question.showProgressBar, "top");
+});
+
+QUnit.test("SurveyModel mode value is always lower-case", function (assert) {
+    var question = new SurveyModel("text");
+    question.mode = "DISPLAY";
+    assert.strictEqual(question.mode, "display");
+});


### PR DESCRIPTION
This is because GraphQl transmits enum values in uppercase. Note
that we needed to add a single exception for 'onPage' as it was
the only enum type in Survey.js that is not entirely lower-case to
begin with.