### PR TITLE
Question Bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.12.16"></a>
+## [0.12.16](https://github.com/surveyjs/surveyjs/compare/v0.12.15...v0.12.16) (2017-05-31)
+
+
+
 <a name="0.12.15"></a>
 ## [0.12.15](https://github.com/surveyjs/surveyjs/compare/v0.12.14...v0.12.15) (2017-05-19)
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build_prod": "npm run build_dev && concurrently \"npm run build_knockout_prod\" \"npm run build_react_prod\" \"npm run build_angular_prod\" \"npm run build_jquery_prod\" \"npm run build_vue_prod\"",
     "lint": "tslint ./src/**/*.ts -t verbose"
   },
-  "version": "0.12.15",
+  "version": "0.12.16",
   "name": "surveyjs",
   "private": true,
   "devDependencies": {

--- a/src/base.ts
+++ b/src/base.ts
@@ -7,7 +7,11 @@ export interface ISurveyData {
     getComment(name: string): string;
     setComment(name: string, newValue: string);
 }
-export interface ISurvey extends ISurveyData {
+export interface ITextProcessor {
+    processText(text: string): string;
+    processTextEx(text: string): any;
+}
+export interface ISurvey extends ISurveyData, ITextProcessor {
     currentPage: IPage;
     pageVisibilityChanged(page: IPage, newValue: boolean);
     questionVisibilityChanged(question: IQuestion, newValue: boolean);
@@ -17,7 +21,6 @@ export interface ISurvey extends ISurveyData {
     panelRemoved(panel: IElement);
     validateQuestion(name: string): SurveyError;
     processHtml(html: string): string;
-    processText(text: string): string;
     isDisplayMode: boolean;
     isDesignMode: boolean;
     isLoadingFromJson: boolean;
@@ -58,6 +61,7 @@ export interface IQuestion extends IElement {
     onReadOnlyChanged();
     supportGoNextPageAutomatic(): boolean;
     clearUnusedValues();
+    onAnyValueChanged();
 }
 export interface IPanel extends IElement {
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -27,6 +27,7 @@ export interface ISurvey extends ISurveyData, ITextProcessor {
     requiredText: string;
     questionStartIndex: string;
     getQuestionTitleTemplate(): string;
+    getQuestionBodyTemplate(): string;
     storeOthersAsComment: boolean;
     uploadFile(name: string, file: File, storeDataAsText: boolean, uploadingCallback: (status: string) => any): boolean;
     afterRenderQuestion(question: IQuestion, htmlElement);
@@ -56,6 +57,7 @@ export interface IElement  extends IConditionRunner{
 
 export interface IQuestion extends IElement {
     hasTitle: boolean;
+    hasBody: boolean;
     setVisibleIndex(value: number);
     onSurveyValueChanged(newValue: any);
     onReadOnlyChanged();

--- a/src/choicesRestfull.ts
+++ b/src/choicesRestfull.ts
@@ -18,6 +18,7 @@ export class ChoicesRestfull extends Base {
         }
         return true;
     }
+    private lastObjHash: string = "";
     protected processedUrl: string = "";
     protected processedPath: string = "";
     public url: string = "";
@@ -36,6 +37,8 @@ export class ChoicesRestfull extends Base {
             this.getResultCallback([]);
             return;
         }
+        if(this.lastObjHash == this.objHash) return;
+        this.lastObjHash = this.objHash;
         if(ChoicesRestfull.getCachedItemsResult(this)) return;
         this.error = null;
         this.sendRequest();

--- a/src/choicesRestfull.ts
+++ b/src/choicesRestfull.ts
@@ -33,7 +33,7 @@ export class ChoicesRestfull extends Base {
         if (!this.url || !this.getResultCallback) return;
         this.processedText(textProcessor);
         if(!this.processedUrl) {
-            this.onLoad(null);
+            this.getResultCallback([]);
             return;
         }
         if(ChoicesRestfull.getCachedItemsResult(this)) return;
@@ -58,7 +58,7 @@ export class ChoicesRestfull extends Base {
     }
     protected sendRequest() {
         var xhr = new XMLHttpRequest();
-        xhr.open('GET', this.url);
+        xhr.open('GET', this.processedUrl);
         xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
         var self = this;
         xhr.onload = function () {

--- a/src/choicesRestfull.ts
+++ b/src/choicesRestfull.ts
@@ -1,4 +1,4 @@
-﻿import {Base, SurveyError} from "./base";
+﻿import {Base, SurveyError, ITextProcessor} from "./base";
 import {ItemValue} from "./itemvalue";
 import {JsonObject} from "./jsonobject";
 import {surveyLocalization} from "./surveyStrings";
@@ -8,12 +8,6 @@ import {CustomError} from "./error";
  * The run method call a restfull service and results can be get on getREsultCallback.
  */
 export class ChoicesRestfull extends Base {
-    public url: string = "";
-    public path: string = "";
-    public valueName: string = "";
-    public titleName: string = "";
-    public getResultCallback: (items: Array<ItemValue>) => void;
-    public error: SurveyError = null;
     private static itemsResult = {};
     private static getCachedItemsResult(obj: ChoicesRestfull): boolean {
         var hash = obj.objHash;
@@ -24,13 +18,45 @@ export class ChoicesRestfull extends Base {
         }
         return true;
     }
+    protected processedUrl: string = "";
+    protected processedPath: string = "";
+    public url: string = "";
+    public path: string = "";
+    public valueName: string = "";
+    public titleName: string = "";
+    public getResultCallback: (items: Array<ItemValue>) => void;
+    public error: SurveyError = null;
     constructor() {
         super();
     }
-    public run() {
+    public run(textProcessor: ITextProcessor = null) {
         if (!this.url || !this.getResultCallback) return;
+        this.processedText(textProcessor);
+        if(!this.processedUrl) {
+            this.onLoad(null);
+            return;
+        }
         if(ChoicesRestfull.getCachedItemsResult(this)) return;
         this.error = null;
+        this.sendRequest();
+    }
+    private processedText(textProcessor: ITextProcessor) {
+        if(textProcessor) {
+            var pUrl = textProcessor.processTextEx(this.url);
+            var pPath = textProcessor.processTextEx(this.path);
+            if(!pUrl.hasAllValuesOnLastRun || !pPath.hasAllValuesOnLastRun) {
+                this.processedUrl = "";
+                this.processedPath = "";
+            } else {
+                this.processedUrl = pUrl.text;
+                this.processedPath = pPath.text;
+            }
+        } else {
+            this.processedUrl = this.url;
+            this.processedPath = this.path;
+        }
+    }
+    protected sendRequest() {
         var xhr = new XMLHttpRequest();
         xhr.open('GET', this.url);
         xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
@@ -84,7 +110,7 @@ export class ChoicesRestfull extends Base {
     }
     private getResultAfterPath(result: any) {
         if (!result) return result;
-        if (!this.path) return result;
+        if (!this.processedPath) return result;
         var pathes = this.getPathes();
         for (var i = 0; i < pathes.length; i++) {
             result = result[pathes[i]];
@@ -94,16 +120,18 @@ export class ChoicesRestfull extends Base {
     }
     private getPathes(): Array<string> {
         var pathes = [];
-        if (this.path.indexOf(';') > -1) {
+        if (this.processedPath.indexOf(';') > -1) {
             pathes = this.path.split(';');
         } else {
-            pathes = this.path.split(',');
+            pathes = this.processedPath.split(',');
         }
-        if (pathes.length == 0) pathes.push(this.path);
+        if (pathes.length == 0) pathes.push(this.processedPath);
         return pathes;
     }
     private getValue(item: any): any {
+        if(!item) return null;
         if (this.valueName) return item[this.valueName];
+        if(!(item instanceof Object)) return item;
         var len = Object.keys(item).length;
         if (len < 1) return null;
         return item[Object.keys(item)[0]];
@@ -112,6 +140,6 @@ export class ChoicesRestfull extends Base {
         if (!this.titleName) return null;
         return item[this.titleName];
     }
-    private get objHash() { return this.url + ";" + this.path + ";" + this.valueName + ";" + this.titleName; }
+    private get objHash() { return this.processedUrl + ";" + this.processedPath + ";" + this.valueName + ";" + this.titleName; }
 }
 JsonObject.metaData.addClass("choicesByUrl", ["url", "path", "valueName", "titleName"], function () { return new ChoicesRestfull(); });

--- a/src/entries/chunks/localization.ts
+++ b/src/entries/chunks/localization.ts
@@ -1,3 +1,4 @@
+import '../../localization/arabic';
 import '../../localization/czech';
 import '../../localization/danish';
 import '../../localization/dutch';

--- a/src/entries/chunks/localization.ts
+++ b/src/entries/chunks/localization.ts
@@ -9,6 +9,7 @@ import '../../localization/greek';
 import '../../localization/icelandic';
 import '../../localization/italian';
 import '../../localization/polish';
+import '../../localization/portuguese';
 import '../../localization/romanian';
 import '../../localization/russian';
 import '../../localization/spanish';

--- a/src/localization/arabic.ts
+++ b/src/localization/arabic.ts
@@ -1,0 +1,35 @@
+import {surveyLocalization} from "../surveyStrings";
+
+export var arabicSurveyStrings = {
+    pagePrevText: "السابق",
+    pageNextText: "التالي",
+    completeText: "انهاء- تم",
+    progressText: "{1} صفحة {0} من",
+    otherItemText: "نص آخر",
+    emptySurvey: "لا توجد صفحة مرئية أو سؤال في المسح",
+    completingSurvey: "شكرا لك لاستكمال الاستبيان!",
+    loadingSurvey: "...يتم تحميل الاستبيان",
+    optionsCaption: "...اختر",
+    requiredError: ".يرجى الإجابة على السؤال",
+    requiredInAllRowsError: "يرجى الإجابة على الأسئلة في جميع الصفوف",
+    numericError: "يجب أن تكون القيمة الرقمية.",
+    textMinLength: "الرجاء إدخال ما لا يقل عن {0} حرف",
+    textMaxLength: "الرجاء إدخال أقل من {0} حرف",
+    textMinMaxLength: "يرجى إدخال أكثر من {0} وأقل من {1} حرف",
+    minRowCountError: "يرجى ملء ما لا يقل عن {0} الصفوف",
+    minSelectError: "يرجى تحديد ما لا يقل عن {0} المتغيرات",
+    maxSelectError: "يرجى تحديد ما لا يزيد عن {0} المتغيرات",
+    numericMinMax: "و'{0}' يجب أن تكون مساوية أو أكثر من {1} ويساوي أو أقل من {2}ا",
+    numericMin: "و'{0}' يجب أن تكون مساوية أو أكثر من {1}ا",
+    numericMax: "و'{0}' يجب أن تكون مساوية أو أقل من {1}ا",
+    invalidEmail: "رجاء قم بإدخال بريد الكتروني صحيح",
+    urlRequestError: "طلب إرجاع خطأ '{0}'. {1}ا",
+    urlGetChoicesError: "عاد طلب بيانات فارغة أو 'المسار' ممتلكات غير صحيحة ",
+    exceedMaxSize: "وينبغي ألا يتجاوز حجم الملف {0}ا",
+    otherRequiredError: "الرجاء إدخال قيمة أخرى",
+    uploadingFile: "الملف الخاص بك تحميل. يرجى الانتظار عدة ثوان وحاول مرة أخرى",
+    addRow: "اضافة صف",
+    removeRow: "إزالة صف"
+};
+
+surveyLocalization.locales["ar"] = arabicSurveyStrings;

--- a/src/localization/portuguese.ts
+++ b/src/localization/portuguese.ts
@@ -5,11 +5,11 @@ import {
 export var portugueseSurveyStrings = {
 	pagePrevText: "Anterior",
 	pageNextText: "Próximo",
-	completeText: "Completo",
+	completeText: "Finalizar",
 	otherItemText: "Outros (descrever)",
 	progressText: "Pagina {0} de {1}",
 	emptySurvey: "Não há página visível ou pergunta na pesquisa.",
-	completingSurvey: "Obrigado por completar a pesquisa!",
+	completingSurvey: "Obrigado por finalizar a pesquisa!",
 	loadingSurvey: "A pesquisa está carregando...",
 	optionsCaption: "Selecione...",
 	requiredError: "Por favor, responda a pergunta.",

--- a/src/localization/portuguese.ts
+++ b/src/localization/portuguese.ts
@@ -1,0 +1,42 @@
+import {
+	surveyLocalization
+} from "../surveyStrings";
+
+export var portugueseSurveyStrings = {
+	pagePrevText: "Anterior",
+	pageNextText: "Próximo",
+	completeText: "Completo",
+	otherItemText: "Outros (descrever)",
+	progressText: "Pagina {0} de {1}",
+	emptySurvey: "Não há página visível ou pergunta na pesquisa.",
+	completingSurvey: "Obrigado por completar a pesquisa!",
+	loadingSurvey: "A pesquisa está carregando...",
+	optionsCaption: "Selecione...",
+	requiredError: "Por favor, responda a pergunta.",
+	requiredInAllRowsError: "Por favor, responda as perguntas em todas as linhas.",
+	numericError: "O valor deve ser numérico.",
+	textMinLength: "Por favor, insira pelo menos {0} caracteres.",
+	textMaxLength: "Por favor, insira menos de {0} caracteres.",
+	textMinMaxLength: "Por favor, insira mais de {0} e menos de {1} caracteres.",
+	minRowCountError: "Preencha pelo menos {0} linhas.",
+	minSelectError: "Selecione pelo menos {0} opções.",
+	maxSelectError: "Por favor, selecione não mais do que {0} opções.",
+	numericMinMax: "O '{0}' deve ser igual ou superior a {1} e igual ou menor que {2}",
+	numericMin: "O '{0}' deve ser igual ou superior a {1}",
+	numericMax: "O '{0}' deve ser igual ou inferior a {1}",
+	invalidEmail: "Por favor, informe um e-mail válido.",
+	urlRequestError: "A requisição retornou o erro '{0}'. {1}",
+	urlGetChoicesError: "A requisição não retornou dados ou o 'caminho' da requisição não está correto",
+	exceedMaxSize: "O tamanho do arquivo não deve exceder {0}.",
+	otherRequiredError: "Por favor, informe o outro valor.",
+	uploadingFile: "Seu arquivo está sendo carregado. Por favor, aguarde alguns segundos e tente novamente.",
+	addRow: "Adicionar linha",
+	removeRow: "Remover linha",
+	choices_firstItem: "primeiro item",
+	choices_secondItem: "segundo item",
+	choices_thirdItem: "terceiro item",
+	matrix_column: "Coluna",
+	matrix_row: "Linha"
+};
+
+surveyLocalization.locales["pt"] = portugueseSurveyStrings;

--- a/src/question.ts
+++ b/src/question.ts
@@ -12,6 +12,7 @@ import {ILocalizableOwner, LocalizableString} from "./localizablestring";
  */
 export class Question extends QuestionBase implements IValidatorOwner {
     private locTitleValue: LocalizableString;
+    private locBodyValue: LocalizableString;
     private locCommentTextValue: LocalizableString;
     private questionValue: any;
     private questionComment: string;
@@ -26,15 +27,19 @@ export class Question extends QuestionBase implements IValidatorOwner {
     commentChangedCallback: () => void;
     errorsChangedCallback: () => void;
     titleChangedCallback: () => void;
+    bodyChangedCallback: () => void;
 
     constructor(public name: string) {
         super(name);
         this.locTitleValue = new LocalizableString(this, true);
+        this.locBodyValue = new LocalizableString(this, true);
         var self = this;
         this.locTitleValue.onRenderedHtmlCallback = function(text) { return self.fullTitle; };
+        this.locBodyValue.onRenderedHtmlCallback = function(text) { return self.body; };
         this.locCommentTextValue = new LocalizableString(this, true);
     }
     public get hasTitle(): boolean { return true; }
+    public get hasBody(): boolean { return !!this.locBodyValue.textOrHtml; }
     public get hasInput(): boolean { return true; }
     public get inputId(): string { return this.id + "i"; }
     /** 
@@ -50,6 +55,15 @@ export class Question extends QuestionBase implements IValidatorOwner {
         this.fireCallback(this.titleChangedCallback);
     }
     get locTitle(): LocalizableString { return this.locTitleValue; }
+    public get body(): string {
+        var res = this.locBody.text;
+        return res ? res : this.name;
+    }
+    public set body(newValue: string) {
+        this.locBody.text = newValue;
+        this.fireCallback(this.bodyChangedCallback);
+    }
+    get locBody(): LocalizableString { return this.locBodyValue; }
     get locCommentText(): LocalizableString { return this.locCommentTextValue; }
     private get locTitleHtml(): string {
         var res = this.locTitle.textOrHtml;
@@ -308,5 +322,6 @@ export class Question extends QuestionBase implements IValidatorOwner {
     getValidatorTitle(): string { return null; }
 }
 JsonObject.metaData.addClass("question", [{ name: "title:text", serializationProperty: "locTitle" },
+    { name: "body", serializationProperty: "locBody" },
     { name: "commentText", serializationProperty: "locCommentText" },
     "isRequired:boolean", "readOnly:boolean", { name: "validators:validators", baseClassName: "surveyvalidator", classNamePart: "validator"}], null, "questionbase");

--- a/src/question_baseselect.ts
+++ b/src/question_baseselect.ts
@@ -185,8 +185,14 @@ export class QuestionSelectBase extends Question {
     protected getStoreOthersAsComment() { return this.storeOthersAsComment && (this.survey != null ? this.survey.storeOthersAsComment : true); }
     onSurveyLoad() {
         super.onSurveyLoad();
-        if (this.choicesByUrl) this.choicesByUrl.run();
+        this.runChoicesByUrl();
         this.onVisibleChoicesChanged();
+    }
+    onAnyValueChanged(){
+        this.runChoicesByUrl();
+    }
+    private runChoicesByUrl() {
+        if (this.choicesByUrl) this.choicesByUrl.run(this.survey);
     }
     private onLoadChoicesFromUrl(array: Array<ItemValue>) {
         var errorCount = this.errors.length;

--- a/src/questionbase.ts
+++ b/src/questionbase.ts
@@ -200,9 +200,8 @@ export class QuestionBase extends Base implements IQuestion, IConditionRunner, I
     public onLocaleChanged() {
         this.localeChanged.fire(this, this.getLocale());
     }
-    onReadOnlyChanged() {
-        
-    }
+    onReadOnlyChanged() {}
+    onAnyValueChanged(){}
     //ILocalizableOwner
     /**
      * Returns the current survey locale

--- a/src/questionbase.ts
+++ b/src/questionbase.ts
@@ -103,6 +103,10 @@ export class QuestionBase extends Base implements IQuestion, IConditionRunner, I
      */
     public get hasTitle(): boolean { return false; }
     /**
+     * Returns false if the question doesn't have a body,
+     */
+    public get hasBody(): boolean { return false; }
+    /**
      * Returns false if the question doesn't have an input element, for example: QuestionHtmlModel
      */
     public get hasInput(): boolean { return false; }

--- a/src/react/reactquestion.tsx
+++ b/src/react/reactquestion.tsx
@@ -72,6 +72,9 @@ export class SurveyQuestion extends React.Component<any, any> {
         var title = this.questionBase.hasTitle ? this.renderTitle() : null;
         var titleTop = this.creator.questionTitleLocation() == "top" ? title : null;
         var titleBottom = this.creator.questionTitleLocation() == "bottom" ? title : null;
+        var body = this.questionBase.hasBody ? this.renderBody() : null;
+        var bodyTop = this.creator.questionTitleLocation() == "top" ? body : null;
+        var bodyBottom = this.creator.questionTitleLocation() == "bottom" ? body : null;
         var comment = (this.question && this.question.hasComment) ? this.renderComment() : null;
         var errors = this.renderErrors();
         var paddingLeft = (this.questionBase.indent > 0) ? this.questionBase.indent * this.css.question.indent + "px" : null;
@@ -83,10 +86,12 @@ export class SurveyQuestion extends React.Component<any, any> {
         return (
             <div ref="root" id={this.questionBase.id} className={this.css.question.root} style={rootStyle}>
                 {titleTop}
+                {bodyTop}
                 {errors}
                 {questionRender}
                 {comment}
                 {titleBottom}
+                {bodyBottom}
             </div>
         );
     }
@@ -100,6 +105,10 @@ export class SurveyQuestion extends React.Component<any, any> {
     protected renderTitle(): JSX.Element {
         var titleText = SurveyElementBase.renderLocString(this.question.locTitle);
         return (<h5 className={this.css.question.title}>{titleText}</h5>);
+    }
+    protected renderBody(): JSX.Element {
+        var bodyText = SurveyElementBase.renderLocString(this.question.locBody);
+        return (<div>{bodyText}</div>);
     }
     protected renderComment(): JSX.Element {
         var commentText = SurveyElementBase.renderLocString(this.question.locCommentText);

--- a/src/react/reactquestioncheckbox.tsx
+++ b/src/react/reactquestioncheckbox.tsx
@@ -98,7 +98,7 @@ export class SurveyQuestionCheckboxItem extends SurveyElementBase {
             <div className={this.css.item} style={divStyle}>
                 <label className={this.css.item}>
                     <input type="checkbox" value={this.item.value} id={id} style={this.inputStyle} disabled={this.isDisplayMode} checked={isChecked} onChange={this.handleOnChange} />
-                    <span className="checkbox-material" style={{"margin-right": "5px"}}><span className="check"></span></span>
+                    <span className="checkbox-material" style={{"marginRight": "5px"}}><span className="check"></span></span>
                     <span>{text}</span>
                 </label>
                 {otherItem}

--- a/src/react/reactquestiondropdown.tsx
+++ b/src/react/reactquestiondropdown.tsx
@@ -8,7 +8,7 @@ import {browser, compareVersions} from "../utils";
 export class SurveyQuestionDropdown extends SurveyQuestionElementBase {
     constructor(props: any) {
         super(props);
-        this.state = { value: this.question.value, choicesChanged: 0 };
+        this.state = { value: this.question.value || '', choicesChanged: 0 };
         var self = this;
         this.question.choicesChangedCallback = function () {
             self.state.choicesChanged = self.state.choicesChanged + 1;
@@ -19,11 +19,11 @@ export class SurveyQuestionDropdown extends SurveyQuestionElementBase {
     protected get question(): QuestionDropdownModel { return this.questionBase as QuestionDropdownModel; }
     componentWillReceiveProps(nextProps: any) {
         super.componentWillReceiveProps(nextProps);
-        this.state.value = this.question.value;
+        this.state.value = this.question.value || '';
     }
     handleOnChange(event) {
         this.question.value = event.target.value;
-        this.setState({ value: this.question.value });
+        this.setState({ value: this.question.value || '' });
     }
     render(): JSX.Element {
         if (!this.question) return null;
@@ -42,7 +42,7 @@ export class SurveyQuestionDropdown extends SurveyQuestionElementBase {
         for (var i = 0; i < this.question.visibleChoices.length; i++) {
             var item = this.question.visibleChoices[i];
             var key = "item" + i;
-            var option = <option key={key} value={item.value}>{item.text}</option>;
+            var option = <option key={key} value={item.value} selected={this.state.value == item.value}>{item.text}</option>;
             options.push(option);
         }
 

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -116,6 +116,7 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
     private locPageNextTextValue : LocalizableString;
     private locCompleteTextValue : LocalizableString;
     private locQuestionTitleTemplateValue: LocalizableString;
+    private locQuestionBodyTemplateValue: LocalizableString;
 
     private currentPageValue: PageModel = null;
     private valuesHash: HashTable<any> = {};
@@ -288,6 +289,7 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
         this.locPageNextTextValue = new LocalizableString(this);
         this.locCompleteTextValue = new LocalizableString(this);
         this.locQuestionTitleTemplateValue = new LocalizableString(this, true);
+        this.locQuestionBodyTemplateValue = new LocalizableString(this, true);
 
         this.textPreProcessor = new TextPreProcessor();
         this.textPreProcessor.onHasValue = function (name: string) { return self.hasProcessedTextValue(name); };
@@ -382,6 +384,19 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
      */
     public getQuestionTitleTemplate(): string { return this.locQuestionTitleTemplate.textOrHtml; }
     get locQuestionTitleTemplate(): LocalizableString { return this.locQuestionTitleTemplateValue; }
+    /**
+     * A template for a question body.
+     * @see QuestionModel.body
+     */
+    public get questionBodyTemplate(): string { return this.locQuestionBodyTemplate.text;}
+    public set questionBodyTemplate(value: string) { this.locQuestionBodyTemplate.text = value;}
+    /**
+     * Returns the question body template
+     * @see questionBodyTemplate
+     * @see QuestionModel.body
+     */
+    public getQuestionBodyTemplate(): string { return this.locQuestionBodyTemplate.textOrHtml; }
+    public get locQuestionBodyTemplate(): LocalizableString { return this.locQuestionBodyTemplateValue; }
 
     /**
      * Set this property to false to turn off the numbering on pages titles.

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -1323,7 +1323,7 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
             if (!this.isLastPage) {
                 this.nextPage();
             } else {
-                this.doComplete();
+                this.completeLastPage();
             }
         }
     }

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -1019,6 +1019,9 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
         if(!question) {
             this.onValueChanged.fire(this, { 'name': name, 'question': question, 'value': newValue });
         }
+        for (var i: number = 0; i < questions.length; i++) {
+            questions[i].onAnyValueChanged();
+        }
     }
     private notifyAllQuestionsOnValueChanged() {
         var questions = this.getAllQuestions();
@@ -1400,6 +1403,11 @@ export class SurveyModel extends Base implements ISurvey, ISurveyTriggerOwner, I
     }
     processText(text: string): string {
         return this.textPreProcessor.process(text);
+    }
+    processTextEx(text: string): any {
+        var res = {text : this.textPreProcessor.process(text),  hasAllValuesOnLastRun: true};
+        res.hasAllValuesOnLastRun = this.textPreProcessor.hasAllValuesOnLastRun;
+        return res;
     }
     //ISurveyTriggerOwner
     getObjects(pages: string[], questions: string[]): any[]{

--- a/src/surveyStrings.ts
+++ b/src/surveyStrings.ts
@@ -2,6 +2,7 @@
     currentLocale: "",
     defaultLocale: "en",
     locales: {},
+    supportedLocales: [],
     getString: function (strName: string) {
         var loc = this.currentLocale ? this.locales[this.currentLocale] : this.locales[this.defaultLocale];
         if (!loc || !loc[strName]) loc = this.locales[this.defaultLocale];
@@ -10,8 +11,14 @@
     getLocales: function (): Array<string> {
         var res = [];
         res.push("");
-        for (var key in this.locales) {
-            res.push(key);
+        if(this.supportedLocales && this.supportedLocales.length > 0) {
+            for(var i = 0; i < this.supportedLocales.length; i ++) {
+                res.push(this.supportedLocales[i]);
+            }
+        } else {
+            for (var key in this.locales) {
+                res.push(key);
+            }
         }
         res.sort();
         return res;

--- a/src/surveyStrings.ts
+++ b/src/surveyStrings.ts
@@ -1,9 +1,10 @@
 ﻿export var surveyLocalization = {
     currentLocale: "",
+    defaultLocale: "en",
     locales: {},
     getString: function (strName: string) {
-        var loc = this.currentLocale ? this.locales[this.currentLocale] : surveyStrings;
-        if (!loc || !loc[strName]) loc = surveyStrings;
+        var loc = this.currentLocale ? this.locales[this.currentLocale] : this.locales[this.defaultLocale];
+        if (!loc || !loc[strName]) loc = this.locales[this.defaultLocale];
         return loc[strName];
     },
     getLocales: function (): Array<string> {

--- a/src/textPreProcessor.ts
+++ b/src/textPreProcessor.ts
@@ -22,7 +22,10 @@ export class TextPreProcessor {
                 continue;
             }
             var value = this.onProcess(name);
-            if (value == null) value = "";
+            if (value == null) {
+                 value = "";
+                 this.hasAllValuesOnLastRunValue = false;
+            }
             text = text.substr(0, item.start) + value + text.substr(item.end + 1);
         }
         return text;

--- a/src/textPreProcessor.ts
+++ b/src/textPreProcessor.ts
@@ -4,10 +4,12 @@
 }
 
 export class TextPreProcessor {
+    private hasAllValuesOnLastRunValue : boolean = false;
     public onProcess: (name: string) => any;
     public onHasValue: (name: string) => boolean;
     constructor() { }
     public process(text: string): string {
+        this.hasAllValuesOnLastRunValue = true;
         if (!text) return text;
         if (!this.onProcess) return text;
         var items = this.getItems(text);
@@ -15,13 +17,17 @@ export class TextPreProcessor {
             var item = items[i];
             var name = this.getName(text.substring(item.start + 1, item.end));
             if (!this.canProcessName(name)) continue;
-            if (this.onHasValue && !this.onHasValue(name)) continue;
+            if (this.onHasValue && !this.onHasValue(name)) {
+                this.hasAllValuesOnLastRunValue = false;
+                continue;
+            }
             var value = this.onProcess(name);
             if (value == null) value = "";
             text = text.substr(0, item.start) + value + text.substr(item.end + 1);
         }
         return text;
     }
+    public get hasAllValuesOnLastRun() { return this.hasAllValuesOnLastRunValue; }
     private getItems(text: string): Array<TextPreProcessorItem> {
         var items = [];
         var length = text.length;

--- a/tests/surveyLocalizationTests.ts
+++ b/tests/surveyLocalizationTests.ts
@@ -66,3 +66,10 @@ QUnit.test("set swedish localization", function (assert) {
     assert.equal(survey.completeText, "Färdig");
     surveyLocalization.currentLocale = "";
 });
+QUnit.test("Supported locales", function (assert) {
+    var localesCounts = surveyLocalization.getLocales().length;
+    surveyLocalization.supportedLocales = ["en", "de"];
+    assert.equal(surveyLocalization.getLocales().length, 2 + 1, "We support only two locales now");
+    surveyLocalization.supportedLocales = null;
+    assert.equal(surveyLocalization.getLocales().length, localesCounts, "Support all locales");
+});

--- a/tests/surveyLocalizationTests.ts
+++ b/tests/surveyLocalizationTests.ts
@@ -26,6 +26,13 @@ QUnit.test("add new localization", function (assert) {
     assert.equal(surveyLocalization.getString("pagePrevText"), "Previous");
     surveyLocalization.currentLocale = "";
 });
+QUnit.test("make german as a default location", function (assert) {
+    assert.equal(surveyLocalization.getString("pagePrevText"), "Previous", "Get English string");
+    surveyLocalization.defaultLocale = "de";
+    assert.equal(surveyLocalization.getString("pagePrevText"), "Zurück", "Get German string");
+    surveyLocalization.defaultLocale = "en";
+    assert.equal(surveyLocalization.getString("pagePrevText"), "Previous", "Get English string again");
+});
 QUnit.test("set german localization", function (assert) {
     var locales = surveyLocalization.getLocales();
     assert.ok(locales.indexOf("en") > -1, "has en");


### PR DESCRIPTION
This patch introduces question bodies to surveyjs. It's a fairly large one, unfortunately, because surveyjs is very overarchitected, but when you get past all the layers of superfluous getters and setters and interfaces, all it's really doing is attaching a `body` property to the `Question` class, and making it render under the title in `reactquestion`.

This is probably not yet ready for merge into `surveyjs`; I think it only makes things work in `react`, and `surveyjs` supports a lot more than just `react`. Probably if we want it merged we'll have to support all the other frameworks, too. :<